### PR TITLE
Replace deprecated rspec syntax :should

### DIFF
--- a/spec/headline_spec.rb
+++ b/spec/headline_spec.rb
@@ -3,16 +3,16 @@ require 'spec_helper'
 describe Orgmode::Headline do
 
   it "should recognize headlines that start with asterisks" do
-    Orgmode::Headline.headline?("*** test\n").should_not be_nil
+    expect(Orgmode::Headline.headline?("*** test\n")).to_not be_nil
   end
 
   it "should reject headlines without headlines at the start" do
-    Orgmode::Headline.headline?("  nope!").should be_nil
-    Orgmode::Headline.headline?("  tricked you!!!***").should be_nil
+    expect(Orgmode::Headline.headline?("  nope!")).to be_nil
+    expect(Orgmode::Headline.headline?("  tricked you!!!***")).to be_nil
   end
 
   it "should reject improper initialization" do
-    lambda { Orgmode::Headline.new " tricked**" }.should raise_error
+    expect { Orgmode::Headline.new " tricked**" }.to raise_error
   end
 
   it "should properly determine headline level" do
@@ -20,44 +20,44 @@ describe Orgmode::Headline do
     expected = 1
     samples.each do |sample|
       h = Orgmode::Headline.new sample
-      h.level.should eql(expected)
+      expect(h.level).to eql(expected)
       expected += 1
     end
   end
 
   it "should properly determine headline level with offset" do
     h = Orgmode::Headline.new("* one", nil, 1)
-    h.level.should eql(2)
+    expect(h.level).to eql(2)
   end
 
   it "should find simple headline text" do
     h = Orgmode::Headline.new "*** sample"
-    h.headline_text.should eql("sample")
+    expect(h.headline_text).to eql("sample")
   end
 
   it "should understand tags" do
     h = Orgmode::Headline.new "*** sample :tag:tag2:\n"
-    h.headline_text.should eql("sample")
+    expect(h.headline_text).to eql("sample")
     expect(h.tags.length).to be == 2
-    h.tags[0].should eql("tag")
-    h.tags[1].should eql("tag2")
+    expect(h.tags[0]).to eql("tag")
+    expect(h.tags[1]).to eql("tag2")
   end
 
   it "should understand a single tag" do
     h = Orgmode::Headline.new "*** sample :tag:\n"
-    h.headline_text.should eql("sample")
+    expect(h.headline_text).to eql("sample")
     expect(h.tags.length).to be == 1
-    h.tags[0].should eql("tag")
+    expect(h.tags[0]).to eql("tag")
   end
 
   it "should understand keywords" do
     h = Orgmode::Headline.new "*** TODO Feed cat  :home:"
-    h.headline_text.should eql("Feed cat")
-    h.keyword.should eql("TODO")
+    expect(h.headline_text).to eql("Feed cat")
+    expect(h.keyword).to eql("TODO")
   end
 
   it "should recognize headlines marked as COMMENT" do
     h = Orgmode::Headline.new "* COMMENT This headline is a comment"
-    h.comment_headline?.should_not be_nil
+    expect(h.comment_headline?).not_to be_nil
   end
 end

--- a/spec/line_spec.rb
+++ b/spec/line_spec.rb
@@ -6,13 +6,13 @@ describe Orgmode::Line do
     comments = ["# hello", "#hello" ]
     comments.each do |c|
       line = Orgmode::Line.new c
-      line.comment?.should be_truthy
+      expect(line.comment?).to be_truthy
     end
 
     not_comments = ["", "\n", "hello\n", "  foo ### bar\n"]
     not_comments.each do |c|
       line = Orgmode::Line.new c
-      line.comment?.should_not be_truthy
+      expect(line.comment?).to_not be_truthy
     end
   end
 
@@ -20,13 +20,13 @@ describe Orgmode::Line do
     blank = ["", " ", "\t", "\n", "  \t\t\n\n"]
     blank.each do |b|
       line = Orgmode::Line.new b
-      line.blank?.should be_truthy
+      expect(line.blank?).to be_truthy
     end
   end
 
   [": inline", " : inline", "\t\t:\tinline"].each do |inline_example|
     it "should recognize this inline example: #{inline_example}" do
-      Orgmode::Line.new(inline_example).inline_example?.should be_truthy
+      expect(Orgmode::Line.new(inline_example).inline_example?).to be_truthy
     end
   end
 
@@ -39,44 +39,44 @@ describe Orgmode::Line do
   list_formats.each do |list|
     it "should recognize this list format: '#{list}'" do
       line = Orgmode::Line.new list
-      line.plain_list?.should be_truthy
+      expect(line.plain_list?).to be_truthy
     end
   end
 
   ["-foo", "+foo", "1.foo", "2.foo"].each do |invalid_list|
     it "should not recognize this invalid list: '#{invalid_list}'" do
       line = Orgmode::Line.new invalid_list
-      line.plain_list?.should_not be_truthy
+      expect(line.plain_list?).to_not be_truthy
     end
   end
 
   it "should recognize horizontal rules" do
-    Orgmode::Line.new("-----").horizontal_rule?.should be_truthy
-    Orgmode::Line.new("----------").horizontal_rule?.should be_truthy
-    Orgmode::Line.new("   \t ----- \t\t\t").horizontal_rule?.should be_truthy
-    Orgmode::Line.new("----").horizontal_rule?.should_not be_truthy
+    expect(Orgmode::Line.new("-----").horizontal_rule?).to be_truthy
+    expect(Orgmode::Line.new("----------").horizontal_rule?).to be_truthy
+    expect(Orgmode::Line.new("   \t ----- \t\t\t").horizontal_rule?).to be_truthy
+    expect(Orgmode::Line.new("----").horizontal_rule?).to_not be_truthy
   end
 
   it "should recognize table rows" do
-    Orgmode::Line.new("| One   | Two   | Three |").table_row?.should be_truthy
-    Orgmode::Line.new("  |-------+-------+-------|\n").table_separator?.should be_truthy
-    Orgmode::Line.new("| Four  | Five  | Six   |").table_row?.should be_truthy
-    Orgmode::Line.new("| Seven | Eight | Nine  |").table_row?.should be_truthy
+    expect(Orgmode::Line.new("| One   | Two   | Three |").table_row?).to be_truthy
+    expect(Orgmode::Line.new("  |-------+-------+-------|\n").table_separator?).to be_truthy
+    expect(Orgmode::Line.new("| Four  | Five  | Six   |").table_row?).to be_truthy
+    expect(Orgmode::Line.new("| Seven | Eight | Nine  |").table_row?).to be_truthy
   end
 
   it "should recognize indentation" do
-    Orgmode::Line.new("").indent.should eql(0)
-    Orgmode::Line.new(" a").indent.should eql(1)
-    Orgmode::Line.new("   ").indent.should eql(0)
-    Orgmode::Line.new("   \n").indent.should eql(0)
-    Orgmode::Line.new("   a").indent.should eql(3)
+    expect(Orgmode::Line.new("").indent).to eql(0)
+    expect(Orgmode::Line.new(" a").indent).to eql(1)
+    expect(Orgmode::Line.new("   ").indent).to eql(0)
+    expect(Orgmode::Line.new("   \n").indent).to eql(0)
+    expect(Orgmode::Line.new("   a").indent).to eql(3)
   end
 
   it "should return paragraph type" do
-    Orgmode::Line.new("").paragraph_type.should eql(:blank)
-    Orgmode::Line.new("1. foo").paragraph_type.should eql(:list_item)
-    Orgmode::Line.new("- [ ] checkbox").paragraph_type.should eql(:list_item)
-    Orgmode::Line.new("hello!").paragraph_type.should eql(:paragraph)
+    expect(Orgmode::Line.new("").paragraph_type).to eql(:blank)
+    expect(Orgmode::Line.new("1. foo").paragraph_type).to eql(:list_item)
+    expect(Orgmode::Line.new("- [ ] checkbox").paragraph_type).to eql(:list_item)
+    expect(Orgmode::Line.new("hello!").paragraph_type).to eql(:paragraph)
   end
 
   it "should recognize BEGIN and END comments" do
@@ -94,14 +94,14 @@ describe Orgmode::Line do
 
     begin_examples.each_key do |str|
       line = Orgmode::Line.new str
-      line.begin_block?.should be_truthy
-      line.block_type.should eql(begin_examples[str])
+      expect(line.begin_block?).to be_truthy
+      expect(line.block_type).to eql(begin_examples[str])
     end
 
     end_examples.each_key do |str|
       line = Orgmode::Line.new str
-      line.end_block?.should be_truthy
-      line.block_type.should eql(end_examples[str])
+      expect(line.end_block?).to be_truthy
+      expect(line.block_type).to eql(end_examples[str])
     end
   end
 
@@ -125,14 +125,14 @@ describe Orgmode::Line do
     }
     cases.each_pair do |key, value|
       l = Orgmode::Line.new key
-      l.in_buffer_setting?.should be_truthy
+      expect(l.in_buffer_setting?).to be_truthy
       called = nil
       l.in_buffer_setting? do |k, v|
-        k.should eql(value[:key])
-        v.should eql(value[:value])
+        expect(k).to eql(value[:key])
+        expect(v).to eql(value[:value])
         called = true
       end
-      called.should be_truthy
+      expect(called).to be_truthy
     end
   end
 
@@ -147,19 +147,19 @@ describe Orgmode::Line do
 
     cases.each do |c|
       l = Orgmode::Line.new c
-      l.in_buffer_setting?.should be_nil
+      expect(l.in_buffer_setting?).to be_nil
     end
   end
 
   it "should recognize an included file" do
-    Orgmode::Line.new("#+INCLUDE: \"~/somefile.org\"").include_file?.should be_truthy
+    expect(Orgmode::Line.new("#+INCLUDE: \"~/somefile.org\"").include_file?).to be_truthy
   end
 
   it "should recognize an included file with specific lines" do
-    Orgmode::Line.new("#+INCLUDE: \"~/somefile.org\" :lines \"4-18\"").include_file?.should be_truthy
+    expect(Orgmode::Line.new("#+INCLUDE: \"~/somefile.org\" :lines \"4-18\"").include_file?).to be_truthy
   end
 
   it "should recognize an included code file" do
-    Orgmode::Line.new("#+INCLUDE: \"~/somefile.org\" src ruby").include_file?.should be_truthy
+    expect(Orgmode::Line.new("#+INCLUDE: \"~/somefile.org\" src ruby").include_file?).to be_truthy
   end
 end

--- a/spec/output_buffer_spec.rb
+++ b/spec/output_buffer_spec.rb
@@ -4,16 +4,16 @@ describe Orgmode::OutputBuffer do
 
   it "computes outline level numbering" do
     output_buffer = Orgmode::OutputBuffer.new ""
-    output_buffer.get_next_headline_number(1).should eql("1")
-    output_buffer.get_next_headline_number(1).should eql("2")
-    output_buffer.get_next_headline_number(1).should eql("3")
-    output_buffer.get_next_headline_number(1).should eql("4")
-    output_buffer.get_next_headline_number(2).should eql("4.1")
-    output_buffer.get_next_headline_number(2).should eql("4.2")
-    output_buffer.get_next_headline_number(1).should eql("5")
-    output_buffer.get_next_headline_number(2).should eql("5.1")
-    output_buffer.get_next_headline_number(2).should eql("5.2")
-    output_buffer.get_next_headline_number(4).should eql("5.2.0.1")
+    expect(output_buffer.get_next_headline_number(1)).to eql("1")
+    expect(output_buffer.get_next_headline_number(1)).to eql("2")
+    expect(output_buffer.get_next_headline_number(1)).to eql("3")
+    expect(output_buffer.get_next_headline_number(1)).to eql("4")
+    expect(output_buffer.get_next_headline_number(2)).to eql("4.1")
+    expect(output_buffer.get_next_headline_number(2)).to eql("4.2")
+    expect(output_buffer.get_next_headline_number(1)).to eql("5")
+    expect(output_buffer.get_next_headline_number(2)).to eql("5.1")
+    expect(output_buffer.get_next_headline_number(2)).to eql("5.2")
+    expect(output_buffer.get_next_headline_number(4)).to eql("5.2.0.1")
   end
 
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -6,83 +6,83 @@ describe Orgmode::Parser do
   end
 
   it "should fail on non-existant files" do
-    lambda { parser = Orgmode::Parser.load("does-not-exist.org") }.should raise_error
+    expect { parser = Orgmode::Parser.load("does-not-exist.org") }.to raise_error
   end
 
   it "should load all of the lines" do
     parser = Orgmode::Parser.load(RememberFile)
-    parser.lines.length.should eql(53)
+    expect(parser.lines.length).to eql(53)
   end
 
   it "should find all headlines" do
     parser = Orgmode::Parser.load(RememberFile)
-    expect(parser.headlines.length).to be == 12
+    expect(parser.headlines.length).to eql(12)
   end
 
   it "can find a headline by index" do
     parser = Orgmode::Parser.load(RememberFile)
     line = parser.headlines[1].to_s
-    line.should eql("** YAML header in Webby\n")
+    expect(line).to eql("** YAML header in Webby\n")
   end
 
   it "should determine headline levels" do
     parser = Orgmode::Parser.load(RememberFile)
-    parser.headlines[0].level.should eql(1)
-    parser.headlines[1].level.should eql(2)
+    expect(parser.headlines[0].level).to eql(1)
+    expect(parser.headlines[1].level).to eql(2)
   end
 
   it "should include the property drawer items from a headline" do
     parser = Orgmode::Parser.load(FreeformExampleFile)
-    parser.headlines.first.property_drawer.count.should == 2
-    parser.headlines.first.property_drawer['DATE'].should == '2009-11-26'
-    parser.headlines.first.property_drawer['SLUG'].should == 'future-ideas'
+    expect(parser.headlines.first.property_drawer.count).to eql(2)
+    expect(parser.headlines.first.property_drawer['DATE']).to eql('2009-11-26')
+    expect(parser.headlines.first.property_drawer['SLUG']).to eql('future-ideas')
   end
 
   it "should put body lines in headlines" do
     parser = Orgmode::Parser.load(RememberFile)
-    expect(parser.headlines[0].body_lines.length).to be == 1
-    expect(parser.headlines[1].body_lines.length).to be == 7
+    expect(parser.headlines[0].body_lines.length).to eql(1)
+    expect(parser.headlines[1].body_lines.length).to eql(7)
   end
 
   it "should understand lines before the first headline" do
     parser = Orgmode::Parser.load(FreeformFile)
-    expect(parser.header_lines.length).to be == 19
+    expect(parser.header_lines.length).to eql(19)
   end
 
   it "should load in-buffer settings" do
     parser = Orgmode::Parser.load(FreeformFile)
-    expect(parser.in_buffer_settings.length).to be == 12
-    parser.in_buffer_settings["TITLE"].should eql("Freeform")
-    parser.in_buffer_settings["EMAIL"].should eql("bdewey@gmail.com")
-    parser.in_buffer_settings["LANGUAGE"].should eql("en")
+    expect(parser.in_buffer_settings.length).to eql(12)
+    expect(parser.in_buffer_settings["TITLE"]).to eql("Freeform")
+    expect(parser.in_buffer_settings["EMAIL"]).to eql("bdewey@gmail.com")
+    expect(parser.in_buffer_settings["LANGUAGE"]).to eql("en")
   end
 
   it "should understand OPTIONS" do
     parser = Orgmode::Parser.load(FreeformFile)
-    expect(parser.options.length).to be == 19
-    parser.options["TeX"].should eql("t")
-    parser.options["todo"].should eql("t")
-    parser.options["\\n"].should eql("nil")
-    parser.export_todo?.should be_truthy
+    expect(parser.options.length).to eql(19)
+    expect(parser.options["TeX"]).to eql("t")
+    expect(parser.options["todo"]).to eql("t")
+    expect(parser.options["\\n"]).to eql("nil")
+    expect(parser.export_todo?).to be_truthy
     parser.options.delete("todo")
-    parser.export_todo?.should be_falsey
+    expect(parser.export_todo?).to be_falsey
   end
 
   it "should skip in-buffer settings inside EXAMPLE blocks" do
     parser = Orgmode::Parser.load(FreeformExampleFile)
-    expect(parser.in_buffer_settings.length).to be == 0
+    expect(parser.in_buffer_settings.length).to eql(0)
   end
 
   it "should return a textile string" do
     parser = Orgmode::Parser.load(FreeformFile)
-    parser.to_textile.should be_kind_of(String)
+    expect(parser.to_textile).to be_kind_of(String)
   end
 
   it "should understand export table option" do
     fname = File.join(File.dirname(__FILE__), %w[html_examples skip-table.org])
     data = IO.read(fname)
     p = Orgmode::Parser.new(data)
-    p.export_tables?.should be_falsey
+    expect(p.export_tables?).to be_falsey
   end
 
   context "with a table that begins with a separator line" do
@@ -90,7 +90,7 @@ describe Orgmode::Parser do
     let(:data) { Pathname.new(File.dirname(__FILE__)).join('data', 'tables.org').read }
 
     it "should parse without errors" do
-      parser.headlines.size.should == 2
+      expect(parser.headlines.size).to eql(2)
     end
   end
 
@@ -101,16 +101,16 @@ describe Orgmode::Parser do
     invalid_keywords = %w[TODOX todo inprogress Waiting done cANCELED NEXT |]
     valid_keywords.each do |kw|
       it "should match custom keyword #{kw}" do
-        (kw =~ p.custom_keyword_regexp).should be_truthy
+        expect((kw =~ p.custom_keyword_regexp)).to be_truthy
       end
     end
     invalid_keywords.each do |kw|
       it "should not match custom keyword #{kw}" do
-        (kw =~ p.custom_keyword_regexp).should be_nil
+        expect((kw =~ p.custom_keyword_regexp)).to be_nil
       end
     end
     it "should not match blank as a custom keyword" do
-      ("" =~ p.custom_keyword_regexp).should be_nil
+      expect(("" =~ p.custom_keyword_regexp)).to be_nil
     end
   end
 
@@ -118,8 +118,8 @@ describe Orgmode::Parser do
     fname = File.join(File.dirname(__FILE__), %w[html_examples export-tags.org])
     p = Orgmode::Parser.load(fname)
     it "should load tags" do
-      expect(p.export_exclude_tags.length).to be == 2
-      expect(p.export_select_tags.length).to be == 1
+      expect(p.export_exclude_tags.length).to eql(2)
+      expect(p.export_select_tags.length).to eql(1)
     end
   end
 
@@ -134,11 +134,11 @@ describe Orgmode::Parser do
 
       it "should convert #{basename}.org to Textile" do
         expected = IO.read(textile_name)
-        expected.should be_kind_of(String)
+        expect(expected).to be_kind_of(String)
         parser = Orgmode::Parser.new(IO.read(file))
         actual = parser.to_textile
-        actual.should be_kind_of(String)
-        actual.should == expected
+        expect(actual).to be_kind_of(String)
+        expect(actual).to eql(expected)
       end
     end
   end
@@ -156,18 +156,18 @@ describe Orgmode::Parser do
 
       it "should convert #{basename}.org to HTML" do
         expected = IO.read(textile_name)
-        expected.should be_kind_of(String)
+        expect(expected).to be_kind_of(String)
         parser = Orgmode::Parser.new(IO.read(file), { :allow_include_files => true })
         actual = parser.to_html
-        actual.should be_kind_of(String)
-        actual.should == expected
+        expect(actual).to be_kind_of(String)
+        expect(actual).to eql(expected)
       end
 
       it "should render #{basename}.org to HTML using Tilt templates" do
         ENV['ORG_RUBY_ENABLE_INCLUDE_FILES'] = 'true'
         expected = IO.read(textile_name)
         template = Tilt.new(file).render
-        template.should == expected
+        expect(template).to eql(expected)
         ENV['ORG_RUBY_ENABLE_INCLUDE_FILES'] = ''
       end
     end
@@ -178,7 +178,7 @@ describe Orgmode::Parser do
       org_file = File.join(data_directory, "include-file.org")
       parser = Orgmode::Parser.new(IO.read(org_file), :allow_include_files => false)
       actual = parser.to_html
-      actual.should == expected
+      expect(actual).to eql(expected)
     end
 
     it "should render #+INCLUDE when ORG_RUBY_INCLUDE_ROOT is set" do
@@ -188,7 +188,7 @@ describe Orgmode::Parser do
       org_file = File.join(data_directory, "include-file.org")
       parser = Orgmode::Parser.new(IO.read(org_file))
       actual = parser.to_html
-      actual.should == expected
+      expect(actual).to eql(expected)
       ENV['ORG_RUBY_INCLUDE_ROOT'] = nil
     end
   end
@@ -216,18 +216,18 @@ describe Orgmode::Parser do
 
       it "should convert #{basename}.org to HTML" do
         expected = IO.read(org_filename)
-        expected.should be_kind_of(String)
+        expect(expected).to be_kind_of(String)
         parser = Orgmode::Parser.new(IO.read(file), :allow_include_files => true)
         actual = parser.to_html
-        actual.should be_kind_of(String)
-        actual.should == expected
+        expect(actual).to be_kind_of(String)
+        expect(actual).to eql(expected)
       end
 
       it "should render #{basename}.org to HTML using Tilt templates" do
         ENV['ORG_RUBY_ENABLE_INCLUDE_FILES'] = 'true'
         expected = IO.read(org_filename)
         template = Tilt.new(file).render
-        template.should == expected
+        expect(template).to eql(expected)
         ENV['ORG_RUBY_ENABLE_INCLUDE_FILES'] = ''
       end
     end
@@ -244,11 +244,11 @@ describe Orgmode::Parser do
 
       it "should convert #{basename}.org to Markdown" do
         expected = IO.read(markdown_name)
-        expected.should be_kind_of(String)
+        expect(expected).to be_kind_of(String)
         parser = Orgmode::Parser.new(IO.read(file), :allow_include_files => false)
         actual = parser.to_markdown
-        actual.should be_kind_of(String)
-        actual.should == expected
+        expect(actual).to be_kind_of(String)
+        expect(actual).to eql(expected)
       end
     end
   end

--- a/spec/regexp_helper_spec.rb
+++ b/spec/regexp_helper_spec.rb
@@ -5,22 +5,22 @@ describe Orgmode::RegexpHelper do
     e = Orgmode::RegexpHelper.new
     total = 0
     e.match_all("/italic/") do |border, string|
-      border.should eql("/")
-      string.should eql("italic")
+      expect(border).to eql("/")
+      expect(string).to eql("italic")
       total += 1
     end
-    total.should eql(1)
+    expect(total).to eql(1)
 
     total = 0
     borders = %w[* / ~]
     strings = %w[bold italic verbatim]
     e.match_all("This string contains *bold*, /italic/, and ~verbatim~ text.")\
     do |border, str|
-      border.should eql(borders[total])
-      str.should eql(strings[total])
+      expect(border).to eql(borders[total])
+      expect(str).to eql(strings[total])
       total += 1
     end
-    total.should eql(3)
+    expect(total).to eql(3)
   end
 
   it "should not get confused by links" do
@@ -30,7 +30,7 @@ describe Orgmode::RegexpHelper do
     e.match_all("[[http://www.bing.com/twitter]]") do |border, str|
       total += 1
     end
-    total.should eql(0)
+    expect(total).to eql(0)
   end
 
   it "should correctly perform substitutions" do
@@ -45,7 +45,7 @@ describe Orgmode::RegexpHelper do
     end
     n = e.restore_code_snippets n
 
-    n.should eql("This string contains <strong>bold</strong>, <i>italic</i>, and <code>verbatim</code> text.")
+    expect(n).to eql("This string contains <strong>bold</strong>, <i>italic</i>, and <code>verbatim</code> text.")
   end
 
   it "should allow link rewriting" do
@@ -54,10 +54,10 @@ describe Orgmode::RegexpHelper do
       text ||= link
       "\"#{text}\":#{link}"
     end
-    str.should eql("\"http://www.bing.com\":http://www.bing.com")
+    expect(str).to eql("\"http://www.bing.com\":http://www.bing.com")
     str = e.rewrite_links("<http://www.google.com>") do |link|
       "\"#{link}\":#{link}"
     end
-    str.should eql("\"http://www.google.com\":http://www.google.com")
+    expect(str).to eql("\"http://www.google.com\":http://www.google.com")
   end
 end                             # describe Orgmode::RegexpHelper

--- a/spec/textile_output_buffer_spec.rb
+++ b/spec/textile_output_buffer_spec.rb
@@ -2,20 +2,20 @@ require 'spec_helper'
 
 describe Orgmode::TextileOutputBuffer do
   it "should substitute / with _" do
-    Orgmode::TextileOutputBuffer.new("").inline_formatting("/italic/").should eql("_italic_")
+    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting("/italic/")).to eql("_italic_")
   end
 
   it "should convert simple links" do
-    Orgmode::TextileOutputBuffer.new("").inline_formatting("[[http://www.google.com]]").should \
+    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting("[[http://www.google.com]]")).to \
       eql("\"http://www.google.com\":http://www.google.com")
   end
 
   it "should convert links with text" do
-    Orgmode::TextileOutputBuffer.new("").inline_formatting("[[http://www.google.com][Google]]").should \
+    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting("[[http://www.google.com][Google]]")).to \
       eql("\"Google\":http://www.google.com")
   end
 
   it "should convert spaces in urls" do
-    Orgmode::TextileOutputBuffer.new("").inline_formatting("[[my url]]").should eql("\"my url\":my%20url")
+    expect(Orgmode::TextileOutputBuffer.new("").inline_formatting("[[my url]]")).to eql("\"my url\":my%20url")
   end
 end


### PR DESCRIPTION
I noticed that you submitted a PR off of this branch (thanks for that, I was going to go in and do the same, and that saved me a bunch of time). This continues the work that you're doing there, by also replacing the deprecated `should` syntax with the `expect` syntax. Where
necessary, it replaces `==` and `be ==` with :eql
